### PR TITLE
added hathi overlap record

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.cdlib</groupId>
     <artifactId>d2d-commons</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <name>D2D Commons</name>
     
     <!-- comment -->

--- a/src/main/java/org/cdlib/domain/objects/hathi/OverlapItem.java
+++ b/src/main/java/org/cdlib/domain/objects/hathi/OverlapItem.java
@@ -1,0 +1,72 @@
+package org.cdlib.domain.objects.hathi;
+
+import javax.validation.constraints.NotEmpty;
+import org.cdlib.domain.objects.consortium.MemberCode;
+
+/*
+ * A record for an bibliographic item from the hathitrust
+ * overlap reports. Such items are represented both in the 
+ * member institution catalog, and in the HathiTrust collection.
+ * 
+ */
+public class OverlapItem {
+  
+  private String oclcNumber;
+  private String sysId;
+  private String type;
+  private String access;
+  private String rights;
+  private MemberCode institution;
+  
+  @NotEmpty
+  public String getOclcNumber() {
+    return oclcNumber;
+  }
+  
+  public String getSysId() {
+    return sysId;
+  }
+  
+  @NotEmpty
+  public String getType() {
+    return type;
+  }
+  
+  public String getAccess() {
+    return access;
+  }
+  
+  public String getRights() {
+    return rights;
+  }
+  
+  @NotEmpty
+  public MemberCode getInstitution() {
+    return institution;
+  }
+  
+  public void setOclcNumber(String oclcNumber) {
+    this.oclcNumber = oclcNumber;
+  }
+  
+  public void setSysId(String sysId) {
+    this.sysId = sysId;
+  }
+  
+  public void setType(String type) {
+    this.type = type;
+  }
+  
+  public void setAccess(String access) {
+    this.access = access;
+  }
+  
+  public void setRights(String rights) {
+    this.rights = rights;
+  }
+  
+  public void setInstitution(MemberCode institution) {
+    this.institution = institution;
+  }
+
+}


### PR DESCRIPTION
New class added for Hathi overlap record.

MemberCode can be used optionally as a controlled vocabulary for contributing campus.